### PR TITLE
Removed scientist.com from the list of free email providers

### DIFF
--- a/data/free.txt
+++ b/data/free.txt
@@ -3681,7 +3681,6 @@ schreib-doch-mal-wieder.de
 schweiz.org
 sci.fi
 science.com.au
-scientist.com
 scifianime.com
 scotland.com
 scotlandmail.com


### PR DESCRIPTION
Thank you for providing this library!

I'm with Scientist.com, we purchased the domain in 2016, you can see here on the Way Back Machine: https://web.archive.org/web/20160708160136/http://www.scientist.com/. Prior to that, it was used as a free email service. We still have trouble with certain services believing we offer free hosting and not allowing our employees to sign up, I'm hoping this change will help start to change that.

I already submitted a PR to the npm version of this library which you reference in the README:

https://github.com/willwhite/freemail/pull/81
