### PR TITLE
Remove Fastmail-operated domain incorrectly listed as disposable

### DIFF
--- a/data/disposable.txt
+++ b/data/disposable.txt
@@ -54887,7 +54887,6 @@ nospam.ze.tc
 nospam2me.com
 nospam4.us
 nospamfor.us
-nospammail.net
 nospamme.com
 nospammer.ovh
 nospamthanks.info


### PR DESCRIPTION
Removes nospammail.net from data/disposable.txt. This is a privacy/alias 
domain operated by Fastmail (a legitimate paid email provider), not a 
throwaway address.

data/free.txt correctly lists fastmail.com as a free email provider — 
no change needed there.

Relates to: https://github.com/smudge/freemail/issues/28

**Domain verification (verifymail.io):**
- [x] [nospammail.net](https://verifymail.io/domain/nospammail.net) — Disposable: No, Provider: fastmail.com